### PR TITLE
Make use of C++11 using instead of typedef

### DIFF
--- a/dancex11/configurator/dancex11_config_loader.h
+++ b/dancex11/configurator/dancex11_config_loader.h
@@ -33,7 +33,7 @@ namespace DAnCEX11
 
     using parser_if_type = Config_Parser_T<std::ifstream>;
     using parser_type = parser_if_type::base_type;
-    using string_type = parser_type::string_type ;
+    using string_type = parser_type::string_type;
 
     bool load_deployment_config (const string_type& filename,
                                  Deployment::DeploymentPlan& plugins,
@@ -85,11 +85,11 @@ namespace DAnCEX11
     bool parse_property_definition (const string_type&, Deployment::Property&);
 
   private:
-    typedef std::map<string_type, uint32_t> DeploymentRefMap;
-    typedef std::map<std::string, std::vector<uint32_t> > LocalityInstanceMap;
-    typedef std::map<std::string, LocalityInstanceMap > NodeLocalityMap;
-    typedef std::pair<uint32_t, uint32_t> EndpointIndex;
-    typedef std::map<std::string, std::vector<EndpointIndex> > InstanceEndpointMap;
+    using DeploymentRefMap = std::map<string_type, uint32_t>;
+    using LocalityInstanceMap = std::map<std::string, std::vector<uint32_t> >;
+    using NodeLocalityMap = std::map<std::string, LocalityInstanceMap>;
+    using EndpointIndex = std::pair<uint32_t, uint32_t>;
+    using InstanceEndpointMap = std::map<std::string, std::vector<EndpointIndex> >;
 
     struct state_type
     {

--- a/dancex11/configurator/dancex11_config_parser.h
+++ b/dancex11/configurator/dancex11_config_parser.h
@@ -23,10 +23,10 @@ namespace DAnCEX11
   class Config_Parser_Base_T
   {
   public:
-    typedef Config_Stream_Base_T<CHAR_T, TR> stream_base_type;
-    typedef typename stream_base_type::source_type::char_type char_type;
-    typedef typename stream_base_type::source_type::traits_type traits_type;
-    typedef typename stream_base_type::string_type string_type;
+    using stream_base_type = Config_Stream_Base_T<CHAR_T, TR>;
+    using char_type = typename stream_base_type::source_type::char_type;
+    using traits_type = typename stream_base_type::source_type::traits_type;
+    using string_type = typename stream_base_type::string_type;
 
     enum token_id : uint32_t
     {
@@ -141,8 +141,8 @@ namespace DAnCEX11
     virtual stream_base_type& stream () const = 0;
 
   private:
-    typedef std::map<string_type, token_id> TokenMap;
-    typedef std::map<string_type, type_id> TypeMap;
+    using TokenMap = std::map<string_type, token_id>;
+    using TypeMap = std::map<string_type, type_id>;
 
     static const TokenMap token_map_;
     static const TypeMap type_map_;
@@ -157,9 +157,9 @@ namespace DAnCEX11
                                   typename Stream_::traits_type>
   {
   public:
-    typedef Config_Parser_Base_T<typename Stream_::char_type,
-        typename Stream_::traits_type> base_type;
-    typedef Config_Stream_T<Stream_> stream_type;
+    using base_type = Config_Parser_Base_T<typename Stream_::char_type,
+        typename Stream_::traits_type>;
+    using stream_type = Config_Stream_T<Stream_>;
 
     template <typename ...Args>
     Config_Parser_T(Args&& ...args)

--- a/dancex11/configurator/dancex11_config_stream.h
+++ b/dancex11/configurator/dancex11_config_stream.h
@@ -24,9 +24,9 @@ namespace DAnCEX11
   class Config_Stream_Base_T
   {
   public:
-    typedef std::basic_string<CHAR_T, TR> string_type;
-    typedef std::basic_istream<CHAR_T, TR> source_type;
-    typedef typename source_type::int_type int_type;
+    using string_type = std::basic_string<CHAR_T, TR>;
+    using source_type = std::basic_istream<CHAR_T, TR>;
+    using int_type = typename source_type::int_type;
 
     virtual ~Config_Stream_Base_T () = default;
 
@@ -76,9 +76,9 @@ namespace DAnCEX11
                                   typename Stream_::traits_type>
   {
   public:
-    typedef Config_Stream_Base_T<
+    using base = Config_Stream_Base_T<
         typename Stream_::char_type,
-        typename Stream_::traits_type>  base;
+        typename Stream_::traits_type>;
 
     template <typename ...Args>
     Config_Stream_T(Args&& ...args)

--- a/dancex11/configurator/dancex11_config_util.h
+++ b/dancex11/configurator/dancex11_config_util.h
@@ -23,7 +23,7 @@ namespace DAnCEX11
     template <typename Char_T>
     bool icasecmp(const std::basic_string<Char_T>& l, const std::basic_string<Char_T>& r)
     {
-        typedef typename std::basic_string<Char_T>::value_type valtype;
+        using valtype =  typename std::basic_string<Char_T>::value_type;
         return l.size() == r.size()
             && std::equal(l.cbegin(), l.cend(), r.cbegin(),
                 [](valtype l1, valtype r1)
@@ -33,7 +33,7 @@ namespace DAnCEX11
     template <typename Char_T>
     bool icasencmp(const std::basic_string<Char_T>& l, const std::basic_string<Char_T>& r, uint32_t n)
     {
-        typedef typename std::basic_string<Char_T>::value_type valtype;
+        using valtype = typename std::basic_string<Char_T>::value_type;
         return (l.size() >= n) && (r.size() >= n)
             && std::equal(l.cbegin(), l.cbegin()+n, r.cbegin(),
                 [](valtype l1, valtype r1)
@@ -149,7 +149,7 @@ namespace DAnCEX11
     parse_char (const std::basic_string<Char_T>& token,
                      Config_Loader::literal_type lt)
     {
-      typedef Config_Loader::literal_type literal_type;
+      using literal_type = Config_Loader::literal_type;
       switch (lt.base ())
       {
         case literal_type::lt_char:
@@ -177,7 +177,7 @@ namespace DAnCEX11
     parse_uint (const std::basic_string<Char_T>& token,
                  Config_Loader::literal_type lt)
     {
-      typedef Config_Loader::literal_type literal_type;
+      using literal_type = Config_Loader::literal_type;
       switch (lt.base ())
       {
         case literal_type::lt_char:
@@ -205,7 +205,7 @@ namespace DAnCEX11
     parse_bool (const std::basic_string<Char_T>& token,
                 Config_Loader::literal_type lt)
     {
-      typedef Config_Loader::literal_type literal_type;
+      using literal_type = Config_Loader::literal_type;
       switch (lt.base ())
       {
         case literal_type::lt_char:
@@ -242,7 +242,7 @@ namespace DAnCEX11
     parse_int (const std::basic_string<Char_T>& token,
                  Config_Loader::literal_type lt)
     {
-      typedef Config_Loader::literal_type literal_type;
+      using literal_type = Config_Loader::literal_type;
       switch (lt.base ())
       {
         case literal_type::lt_char:
@@ -270,7 +270,7 @@ namespace DAnCEX11
     parse_dec (const std::basic_string<Char_T>& token,
                  Config_Loader::literal_type lt)
     {
-      typedef Config_Loader::literal_type literal_type;
+      using literal_type = Config_Loader::literal_type;
       switch (lt.base ())
       {
         case literal_type::lt_char:
@@ -298,7 +298,7 @@ namespace DAnCEX11
     parse_string (const std::basic_string<Char_T>& token,
                   Config_Loader::literal_type lt)
     {
-      typedef Config_Loader::literal_type literal_type;
+      using literal_type = Config_Loader::literal_type;
       switch (lt.base ())
       {
         case literal_type::lt_char:

--- a/dancex11/core/dancex11_deployment_plan_loader.h
+++ b/dancex11/core/dancex11_deployment_plan_loader.h
@@ -67,7 +67,7 @@ namespace DAnCEX11
 
     std::string extension (const std::string& path);
 
-    typedef std::map<std::string, Plan_Loader_base*> LoaderMap;
+    using LoaderMap = std::map<std::string, Plan_Loader_base*>;
     LoaderMap loaders_;
     std::mutex lock_;
 

--- a/dancex11/core/dancex11_utility.h
+++ b/dancex11/core/dancex11_utility.h
@@ -19,7 +19,7 @@ namespace DAnCEX11
 {
   namespace Utility
   {
-    typedef std::map< std::string, CORBA::Any > PROPERTY_MAP;
+    using PROPERTY_MAP = std::map<std::string, CORBA::Any>;
 
     DANCEX11_STUB_Export void
     build_property_map (PROPERTY_MAP &map,

--- a/dancex11/domain_deployment_handler/dancex11_ddh_application_impl.cpp
+++ b/dancex11/domain_deployment_handler/dancex11_ddh_application_impl.cpp
@@ -561,8 +561,8 @@ namespace DAnCEX11
   {
     DANCEX11_LOG_TRACE ("DomainApplication_Impl::start");
 
-    typedef Completion_T<ORB_Completion_Wait_Strategy<NA_Result>,
-                         NA_Result> completion_type;
+    using completion_type = Completion_T<ORB_Completion_Wait_Strategy<NA_Result>,
+                         NA_Result>;
     completion_type completion;
     bool failed {};
     std::vector<std::string> errors;
@@ -703,8 +703,8 @@ namespace DAnCEX11
                   "Plan " << this->planUUID_ << " DomainApplication[" << this << "] : " <<  nams_.size ()
                   << " nodes to launch");
 
-    typedef Completion_T<ORB_Completion_Wait_Strategy<NAM_Result>,
-                         NAM_Result> completion_type;
+    using completion_type = Completion_T<ORB_Completion_Wait_Strategy<NAM_Result>,
+                         NAM_Result>;
     completion_type completion;
     bool failed {};
     std::vector<std::string> errors;
@@ -866,8 +866,8 @@ namespace DAnCEX11
   {
     DANCEX11_LOG_TRACE ("DomainApplication_Impl::stop");
 
-    typedef Completion_T<ORB_Completion_Wait_Strategy<NA_Result>,
-                         NA_Result> completion_type;
+    using completion_type = Completion_T<ORB_Completion_Wait_Strategy<NA_Result>,
+                         NA_Result> ;
     completion_type completion;
     bool failed {};
     std::vector<std::string> errors;
@@ -1006,8 +1006,8 @@ namespace DAnCEX11
                   "Plan " << this->planUUID_ << " DomainApplication[" << this
                   << "] : " <<  this->node_applications_.size ()<< " node applications to destroy");
 
-    typedef Completion_T<ORB_Completion_Wait_Strategy<NAM_Result>,
-                         NAM_Result> completion_type;
+    using completion_type = Completion_T<ORB_Completion_Wait_Strategy<NAM_Result>,
+                         NAM_Result>;
     completion_type completion;
     bool failed {};
     std::vector<std::string> errors;

--- a/dancex11/domain_deployment_handler/dancex11_ddh_application_impl.h
+++ b/dancex11/domain_deployment_handler/dancex11_ddh_application_impl.h
@@ -29,15 +29,15 @@ namespace DAnCEX11
     {
     public:
 
-      typedef std::pair < IDL::traits< ::Deployment::NodeManager>::ref_type , std::string> TNm2Id_PAIR;
-      typedef std::pair < IDL::traits< ::Deployment::NodeApplicationManager>::ref_type,IDL::traits< ::Deployment::NodeManager>::ref_type> TNam2Nm_PAIR;
-      typedef std::pair < IDL::traits< ::Deployment::Application>::ref_type, IDL::traits< ::Deployment::NodeApplicationManager>::ref_type> TApp2Mgr_PAIR;
-      typedef std::pair < IDL::traits< ::Deployment::Application>::ref_type, std::string > TApp2Id_PAIR;
+      using TNm2Id_PAIR = std::pair <IDL::traits< ::Deployment::NodeManager>::ref_type , std::string>;
+      using TNam2Nm_PAIR = std::pair <IDL::traits< ::Deployment::NodeApplicationManager>::ref_type,IDL::traits< ::Deployment::NodeManager>::ref_type>;
+      using TApp2Mgr_PAIR = std::pair <IDL::traits< ::Deployment::Application>::ref_type, IDL::traits< ::Deployment::NodeApplicationManager>::ref_type>;
+      using TApp2Id_PAIR = std::pair <IDL::traits< ::Deployment::Application>::ref_type, std::string>;
 
-      typedef std::vector < TNam2Nm_PAIR > TNam2Nm;
-      typedef std::vector < TNm2Id_PAIR> TNm2Id;
-      typedef std::vector < TApp2Mgr_PAIR > TApp2Mgr;
-      typedef std::vector < TApp2Id_PAIR > TApp2Id;
+      using TNam2Nm = std::vector <TNam2Nm_PAIR>;
+      using TNm2Id = std::vector <TNm2Id_PAIR>;
+      using TApp2Mgr = std::vector <TApp2Mgr_PAIR>;
+      using TApp2Id = std::vector <TApp2Id_PAIR>;
 
       DomainApplication_Impl (const std::string& plan_uuid,
                               IDL::traits<PortableServer::POA>::ref_type poa,

--- a/dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.cpp
+++ b/dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.cpp
@@ -46,7 +46,7 @@ namespace DAnCEX11
     : public CORBA::amic_traits<Deployment::NodeManager>::replyhandler_base_type
   {
   public:
-    typedef ACE_Future <NM_Result> future_type;
+    using future_type = ACE_Future <NM_Result>;
 
     NodeManager_ReplyHandler (IDL::traits<PortableServer::POA>::ref_type poa,
                               IDL::traits<Deployment::NodeManager>::ref_type nm,
@@ -428,8 +428,8 @@ namespace DAnCEX11
   {
     DANCEX11_LOG_TRACE ("DomainApplicationManager_Impl::preparePlan()");
 
-    typedef Completion_T<ORB_Completion_Wait_Strategy<NM_Result>,
-                         NM_Result> completion_type;
+    using completion_type = Completion_T<ORB_Completion_Wait_Strategy<NM_Result>,
+                         NM_Result>;
     completion_type completion;
     bool failed {};
     std::vector<std::string> errors;
@@ -629,8 +629,8 @@ namespace DAnCEX11
     }
 
     // now call destroyManager() for all node-app managers
-    typedef Completion_T<ORB_Completion_Wait_Strategy<NM_Result>,
-                         NM_Result> completion_type;
+    using completion_type = Completion_T<ORB_Completion_Wait_Strategy<NM_Result>,
+                         NM_Result>;
     completion_type completion;
     bool failed {};
     std::vector<std::string> errors;

--- a/dancex11/domain_deployment_handler/dancex11_domain_dmh_loader.cpp
+++ b/dancex11/domain_deployment_handler/dancex11_domain_dmh_loader.cpp
@@ -15,8 +15,8 @@
 
 namespace DAnCEX11
 {
-  // Typedef to help declare the standardized factory name
-  typedef Domain_DMHandler_Loader DAnCEX11_DeploymentHandler_Impl;
+  // Type to help declare the standardized factory name
+  using DAnCEX11_DeploymentHandler_Impl = Domain_DMHandler_Loader;
 
   // Define the static Service descriptor.
   // Note the standardized name for the factory method declaration.
@@ -29,7 +29,7 @@ namespace DAnCEX11
                          0)
   // Define implementation for Service factory method and cleanup method
   // (gobbler).
-  // Instead of the real classname a typedef is used to force generation
+  // Instead of the real classname a type is used to force generation
   // of the standardized factory method name.
   ACE_FACTORY_DEFINE (DANCEX11_DOMAIN_DH, DAnCEX11_DeploymentHandler_Impl)
 

--- a/dancex11/domain_deployment_handler/dancex11_node_locator.h
+++ b/dancex11/domain_deployment_handler/dancex11_node_locator.h
@@ -36,7 +36,7 @@ namespace DAnCEX11
                              const ::Deployment::Resources &resources,
                              ::Deployment::Resource &val);
 
-    typedef std::map<std::string, std::string> NODEMAP;
+    using NODEMAP = std::map<std::string, std::string>;
 
     NODEMAP nodes_;
     IDL::traits<CORBA::ORB>::ref_type orb_;

--- a/dancex11/handler/instance/locality_activator_impl.h
+++ b/dancex11/handler/instance/locality_activator_impl.h
@@ -107,7 +107,7 @@ namespace DAnCEX11
       IDL::traits<DAnCEX11::DeploymentManagerHandler>::ref_type dmh_;
     };
 
-    typedef std::shared_ptr<Server_Info> Safe_Server_Info;
+    using Safe_Server_Info = std::shared_ptr<Server_Info>;
 
     IDL::traits< ::DAnCEX11::LocalityManager>::ref_type
     activate_remote_locality (Safe_Server_Info ssi);
@@ -171,7 +171,7 @@ namespace DAnCEX11
     };
 
     // Presumably, there won't be too many component servers per node application
-    typedef std::set <Safe_Server_Info, _server_info> SERVER_INFOS;
+    using SERVER_INFOS = std::set <Safe_Server_Info, _server_info>;
 
     TAO_SYNCH_MUTEX container_mutex_;
 

--- a/dancex11/locality_deployment_handler/dancex11_locality_dmh_loader.cpp
+++ b/dancex11/locality_deployment_handler/dancex11_locality_dmh_loader.cpp
@@ -17,8 +17,8 @@
 
 namespace DAnCEX11
 {
-  // Typedef to help declare the standardized factory name
-  typedef Locality_DMHandler_Loader DAnCEX11_DeploymentHandler_Impl;
+  // Type to help declare the standardized factory name
+  using DAnCEX11_DeploymentHandler_Impl = Locality_DMHandler_Loader;
 
   // Define the static Service descriptor.
   // Note the standardized name for the factory method declaration.
@@ -31,7 +31,7 @@ namespace DAnCEX11
                          0)
   // Define implementation for Service factory method and cleanup method
   // (gobbler).
-  // Instead of the real classname a typedef is used to force generation
+  // Instead of the real classname a type is used to force generation
   // of the standardized factory method name.
   ACE_FACTORY_DEFINE (DANCEX11_LOCALITY_DH, DAnCEX11_DeploymentHandler_Impl)
 

--- a/dancex11/locality_deployment_handler/dancex11_locality_manager_impl.cpp
+++ b/dancex11/locality_deployment_handler/dancex11_locality_manager_impl.cpp
@@ -377,7 +377,7 @@ namespace DAnCEX11
   {
     DANCEX11_LOG_TRACE ("LocalityManager_i::finishLaunch");
 
-    typedef std::map< std::string, uint32_t > ConnMap;
+    using ConnMap = std::map<std::string, uint32_t>;
     ConnMap conns;
 
     Deployment_Completion completion (*this->scheduler_);

--- a/dancex11/locality_deployment_handler/dancex11_locality_manager_impl.h
+++ b/dancex11/locality_deployment_handler/dancex11_locality_manager_impl.h
@@ -97,10 +97,10 @@ namespace DAnCEX11
 
     IDL::traits< ::DAnCEX11::ShutdownHandler>::ref_type sh_;
 
-    typedef std::list<uint32_t> INSTANCE_LIST;
+    using INSTANCE_LIST = std::list<uint32_t> ;
 
-    typedef std::pair<std::string, INSTANCE_LIST> HANDLER_TABLE_PAIR;
-    typedef std::map<std::string, INSTANCE_LIST> HANDLER_TABLE;
+    using HANDLER_TABLE_PAIR = std::pair<std::string, INSTANCE_LIST>;
+    using HANDLER_TABLE = std::map<std::string, INSTANCE_LIST>;
 
     HANDLER_TABLE instance_handlers_;
 

--- a/dancex11/logger/log.h
+++ b/dancex11/logger/log.h
@@ -63,7 +63,7 @@ namespace DAnCEX11
     public:
       virtual ~DANCEX11_Log_Msg();
 
-      typedef x11_logger::Log_Type_T<DANCEX11_Log_Msg> log_type;
+      using log_type = x11_logger::Log_Type_T<DANCEX11_Log_Msg>;
 
       static DANCEX11_Log_Msg* getInstance();
 

--- a/dancex11/node_deployment_handler/dancex11_ndh_application_impl.h
+++ b/dancex11/node_deployment_handler/dancex11_ndh_application_impl.h
@@ -60,8 +60,8 @@ namespace DAnCEX11
 
     using LOCALITY_MAP = std::map <std::string, IDL::traits< ::DAnCEX11::LocalityManager>::ref_type>;
 
-    typedef std::pair <uint32_t, ::Deployment::DeploymentPlan> SUB_PLAN;
-    typedef std::map <std::string, SUB_PLAN> PLAN_MAP;
+    using SUB_PLAN = std::pair <uint32_t, ::Deployment::DeploymentPlan>;
+    using PLAN_MAP = std::map <std::string, SUB_PLAN>;
 
   protected:
     void prepare_instance (const std::string & name,

--- a/dancex11/node_deployment_handler/dancex11_ndh_manager_impl.h
+++ b/dancex11/node_deployment_handler/dancex11_ndh_manager_impl.h
@@ -55,7 +55,7 @@ namespace DAnCEX11
     IDL::traits< ::DAnCEX11::ShutdownHandler>::ref_type sh_;
     std::string name_;
     std::string domain_nc_;
-    typedef std::map<std::string, CORBA::servant_reference<NodeApplicationManager_Impl>> TManagers;
+    using TManagers = std::map<std::string, CORBA::servant_reference<NodeApplicationManager_Impl>>;
     TManagers managers_;
     std::shared_ptr<Plugin_Manager> plugins_;
   };

--- a/dancex11/node_deployment_handler/dancex11_node_dmh_loader.cpp
+++ b/dancex11/node_deployment_handler/dancex11_node_dmh_loader.cpp
@@ -14,8 +14,8 @@
 
 namespace DAnCEX11
 {
-  // Typedef to help declare the standardized factory name
-  typedef Node_DMHandler_Loader DAnCEX11_DeploymentHandler_Impl;
+  // Type to help declare the standardized factory name
+  using DAnCEX11_DeploymentHandler_Impl = Node_DMHandler_Loader;
 
   // Define the static Service descriptor.
   // Note the standardized name for the factory method declaration.
@@ -28,7 +28,7 @@ namespace DAnCEX11
                          0)
   // Define implementation for Service factory method and cleanup method
   // (gobbler).
-  // Instead of the real classname a typedef is used to force generation
+  // Instead of the real classname a type is used to force generation
   // of the standardized factory method name.
   ACE_FACTORY_DEFINE (DANCEX11_NODE_DH, DAnCEX11_DeploymentHandler_Impl)
 

--- a/dancex11/scheduler/completion_base.h
+++ b/dancex11/scheduler/completion_base.h
@@ -36,10 +36,10 @@ namespace DAnCEX11
     , public virtual Completion_Counter_Base< ACE_SYNCH_MUTEX >
   {
   public:
-    typedef RESULT result_type;
-    typedef ACE_Future< RESULT > future_type;
+    using result_type = RESULT;
+    using future_type = ACE_Future<RESULT>;
 
-    typedef std::list < future_type > future_list;
+    using future_list = std::list <future_type>;
 
     template <typename ...Args>
     Completion_T (Args&& ...args)

--- a/dancex11/scheduler/completion_counter_base.h
+++ b/dancex11/scheduler/completion_counter_base.h
@@ -23,8 +23,8 @@ namespace DAnCEX11
   class Completion_Counter_Base
   {
   public:
-    typedef ACE_LOCK lock_type;
-    typedef std::vector< std::string > errors_type;
+    using lock_type = ACE_LOCK ;
+    using errors_type = std::vector<std::string>;
 
     Completion_Counter_Base (uint32_t exec_count,
       uint32_t fail_count);

--- a/dancex11/scheduler/dependency_sorter.h
+++ b/dancex11/scheduler/dependency_sorter.h
@@ -19,8 +19,8 @@ namespace DAnCEX11
   class Dependency_Sorter final
   {
   public:
-    typedef std::vector < std::string > INSTALL_ORDER;
-    typedef std::set < std::string > IH_DEPS;
+    using INSTALL_ORDER = std::vector <std::string>;
+    using IH_DEPS = std::set <std::string>;
 
     class Invalid_Install_Order
       : std::exception {};
@@ -43,7 +43,7 @@ namespace DAnCEX11
     calculate_order (INSTALL_ORDER &);
 
   private:
-    typedef std::map< std::string, IH_DEPS > DEP_MAP;
+    using DEP_MAP = std::map<std::string, IH_DEPS>;
 
     DEP_MAP dep_map_;
   };

--- a/dancex11/scheduler/deployment_completion.h
+++ b/dancex11/scheduler/deployment_completion.h
@@ -19,7 +19,7 @@ namespace DAnCEX11
   /**
    * Deployment_Completion
    */
-  typedef Completion_T<Default_Completion_Wait_Strategy<Event_Result>, Event_Result> Deployment_Completion;
+  using Deployment_Completion = Completion_T<Default_Completion_Wait_Strategy<Event_Result>, Event_Result>;
 }
 
 #endif /* DAnCEX11_DEPLOYMENT_COMPLETION_H */

--- a/dancex11/scheduler/deployment_default_wait_strategy.h
+++ b/dancex11/scheduler/deployment_default_wait_strategy.h
@@ -21,7 +21,7 @@ namespace DAnCEX11
   class Default_Completion_Wait_Strategy final
   {
   public:
-    typedef Completion_T<Default_Completion_Wait_Strategy, RESULT> completion_type;
+    using completion_type = Completion_T<Default_Completion_Wait_Strategy, RESULT>;
 
     Default_Completion_Wait_Strategy (
         completion_type &counter,

--- a/dancex11/scheduler/deployment_orb_wait_strategy.h
+++ b/dancex11/scheduler/deployment_orb_wait_strategy.h
@@ -21,8 +21,8 @@ namespace DAnCEX11
   class ORB_Completion_Wait_Strategy final
   {
   public:
-    typedef RESULT result_type;
-    typedef Completion_T<ORB_Completion_Wait_Strategy, result_type> completion_type;
+    using result_type = RESULT;
+    using completion_type = Completion_T<ORB_Completion_Wait_Strategy, result_type>;
 
     ORB_Completion_Wait_Strategy (
         completion_type &counter,

--- a/dancex11/scheduler/events/plugin_manager.h
+++ b/dancex11/scheduler/events/plugin_manager.h
@@ -40,7 +40,7 @@ namespace DAnCEX11
     void
     add_configuration (const Deployment::Properties &config);
 
-    typedef Dependency_Sorter::IH_DEPS IH_DEPS;
+    using IH_DEPS = Dependency_Sorter::IH_DEPS;
 
     /// Registers another installation handler.
     std::string
@@ -59,7 +59,7 @@ namespace DAnCEX11
         uint32_t open_mode,
         Utility::PROPERTY_MAP& config);
 
-    typedef Dependency_Sorter::INSTALL_ORDER INSTALL_ORDER;
+    using INSTALL_ORDER = Dependency_Sorter::INSTALL_ORDER;
 
     void
     get_installation_order (INSTALL_ORDER &);
@@ -67,8 +67,7 @@ namespace DAnCEX11
     IDL::traits<DAnCEX11::InstanceDeploymentHandler>::ref_type
     fetch_installation_handler (const std::string &instance_type);
 
-    typedef std::list < IDL::traits<DAnCEX11::DeploymentInterceptor>::ref_type>
-      INTERCEPTORS;
+    using INTERCEPTORS = std::list <IDL::traits<DAnCEX11::DeploymentInterceptor>::ref_type>;
 
     const INTERCEPTORS &
     fetch_interceptors ();
@@ -98,17 +97,17 @@ namespace DAnCEX11
   private:
     Deployment::Properties config_;
 
-    typedef std::pair < std::string,
-      IDL::traits<DAnCEX11::InstanceDeploymentHandler>::ref_type> HANDLER_MAP_PAIR;
-    typedef std::map < std::string,
-      IDL::traits<DAnCEX11::InstanceDeploymentHandler>::ref_type> HANDLER_MAP;
+    using HANDLER_MAP_PAIR = std::pair <std::string,
+      IDL::traits<DAnCEX11::InstanceDeploymentHandler>::ref_type>;
+    using HANDLER_MAP = std::map <std::string,
+      IDL::traits<DAnCEX11::InstanceDeploymentHandler>::ref_type>;
 
-    typedef std::pair < std::string,
-      IDL::traits<DeploymentConfiguration>::ref_type> CONFIG_MAP_PAIR;
-    typedef std::map < std::string,
-      IDL::traits<DeploymentConfiguration>::ref_type> CONFIG_MAP;
+    using CONFIG_MAP_PAIR = std::pair <std::string,
+      IDL::traits<DeploymentConfiguration>::ref_type>;
+    using CONFIG_MAP = std::map <std::string,
+      IDL::traits<DeploymentConfiguration>::ref_type>;
 
-    typedef std::vector < std::string >   SVCOBJ_LIST;
+    using SVCOBJ_LIST = std::vector <std::string>;
 
     HANDLER_MAP handler_map_;
 

--- a/tools/artifact_installation/dance_artifact_installation_handler.h
+++ b/tools/artifact_installation/dance_artifact_installation_handler.h
@@ -44,7 +44,7 @@ namespace DAnCEX11
   class DAnCE_Artifact_Installation_Export ArtifactInstallationProperties
   {
     public:
-      typedef ArtifactInstallationHandler::TPropertyMap TPropertyMap;
+      using TPropertyMap = ArtifactInstallationHandler::TPropertyMap;
 
       ArtifactInstallationProperties (const TPropertyMap& propmap);
       ArtifactInstallationProperties (const TPropertyMap& propmap, const std::string& protocol);

--- a/tools/artifact_installation/installation_repository_manager.h
+++ b/tools/artifact_installation/installation_repository_manager.h
@@ -21,8 +21,8 @@ namespace DAnCEX11
     class DAnCE_Artifact_Installation_Export InstallationRepository
       {
         public:
-          typedef std::shared_ptr<InstallationRepository> ref_t;
-          typedef std::vector<std::string> TLocations;
+          using ref_t = std::shared_ptr<InstallationRepository>;
+          using TLocations = std::vector<std::string>;
 
           virtual ~InstallationRepository () = default;
 
@@ -51,7 +51,7 @@ namespace DAnCEX11
     class DAnCE_Artifact_Installation_Export InstallationRepositoryManager
       {
         public:
-          typedef InstallationRepository::TLocations TRepositoryIds;
+          using TRepositoryIds = InstallationRepository::TLocations;
 
           virtual ~InstallationRepositoryManager () = default;
 

--- a/tools/config_handlers/config_xml_typedefs.h
+++ b/tools/config_handlers/config_xml_typedefs.h
@@ -19,10 +19,10 @@ namespace XML
   class Config_Handlers_Export DANCEX11_XML_Typedef
   {
   public:
-    typedef ::XML::Environment_Resolver PATH_RESOLVER;
-    typedef ::XML::XML_Schema_Resolver< ::XML::Environment_Resolver > XML_RESOLVER;
-    typedef ::XML::DANCEX11_XML_Error_Handler DANCEX11_ERROR_HANDLER;
-    typedef ::XML::XML_Helper< XML_RESOLVER, DANCEX11_ERROR_HANDLER > HELPER;
+    using PATH_RESOLVER = ::XML::Environment_Resolver;
+    using XML_RESOLVER = ::XML::XML_Schema_Resolver< ::XML::Environment_Resolver>;
+    using DANCEX11_ERROR_HANDLER = ::XML::DANCEX11_XML_Error_Handler ;
+    using HELPER = ::XML::XML_Helper<XML_RESOLVER, DANCEX11_ERROR_HANDLER>;
 
     static DANCEX11_ERROR_HANDLER _xml_error_handler;
 

--- a/tools/config_handlers/xml_file_intf.h
+++ b/tools/config_handlers/xml_file_intf.h
@@ -51,7 +51,7 @@ namespace DAnCEX11
       std::string file_;
       std::unique_ptr< ::Deployment::DeploymentPlan> idl_dp_;
       std::unique_ptr< ::Deployment::Domain> idl_domain_;
-      typedef ::XML::DANCEX11_XML_Typedef XML_Helper_type;
+      using XML_Helper_type = ::XML::DANCEX11_XML_Typedef;
     };
   }
 }

--- a/tools/split_plan/locality_splitter.h
+++ b/tools/split_plan/locality_splitter.h
@@ -18,7 +18,7 @@ namespace DAnCEX11
   class DAnCE_Split_Plan_Export Locality_Splitter
   {
   public:
-    typedef std::vector<uint32_t>  TInstanceList;
+    using TInstanceList = std::vector<uint32_t>;
 
     class DAnCE_Split_Plan_Export LocalityKey
     {
@@ -95,10 +95,10 @@ namespace DAnCEX11
       }
     };
 
-    typedef LocalityKey       KEY;
-    typedef LocalityKeyHash   KEY_HASH;
+    using KEY = LocalityKey;
+    using KEY_HASH = LocalityKeyHash;
 
-    typedef std::vector<std::string>  TInstanceNames;
+    using TInstanceNames = std::vector<std::string>;
 
     class DAnCE_Split_Plan_Export LocalityFilter
     {
@@ -118,7 +118,7 @@ namespace DAnCEX11
       TInstanceNames included_instances_;
     };
 
-    typedef LocalityFilter    FILTER;
+    using FILTER = LocalityFilter;
 
     Locality_Splitter (const Deployment::DeploymentPlan &plan);
 

--- a/tools/split_plan/node_splitter.h
+++ b/tools/split_plan/node_splitter.h
@@ -17,8 +17,8 @@ namespace DAnCEX11
   class DAnCE_Split_Plan_Export Node_Splitter
   {
   public:
-    typedef std::string       KEY;
-    typedef std::string       FILTER;
+    using KEY = std::string;
+    using FILTER = std::string;
 
     Node_Splitter (const Deployment::DeploymentPlan &plan);
 


### PR DESCRIPTION
    * dancex11/configurator/dancex11_config_loader.h:
    * dancex11/configurator/dancex11_config_parser.h:
    * dancex11/configurator/dancex11_config_stream.h:
    * dancex11/configurator/dancex11_config_util.h:
    * dancex11/core/dancex11_deployment_plan_loader.h:
    * dancex11/core/dancex11_utility.h:
    * dancex11/domain_deployment_handler/dancex11_ddh_application_impl.cpp:
    * dancex11/domain_deployment_handler/dancex11_ddh_application_impl.h:
    * dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.cpp:
    * dancex11/domain_deployment_handler/dancex11_domain_dmh_loader.cpp:
    * dancex11/domain_deployment_handler/dancex11_node_locator.h:
    * dancex11/handler/instance/locality_activator_impl.h:
    * dancex11/locality_deployment_handler/dancex11_locality_dmh_loader.cpp:
    * dancex11/locality_deployment_handler/dancex11_locality_manager_impl.cpp:
    * dancex11/locality_deployment_handler/dancex11_locality_manager_impl.h:
    * dancex11/logger/log.h:
    * dancex11/node_deployment_handler/dancex11_ndh_application_impl.h:
    * dancex11/node_deployment_handler/dancex11_ndh_manager_impl.h:
    * dancex11/node_deployment_handler/dancex11_node_dmh_loader.cpp:
    * dancex11/scheduler/completion_base.h:
    * dancex11/scheduler/completion_counter_base.h:
    * dancex11/scheduler/dependency_sorter.h:
    * dancex11/scheduler/deployment_completion.h:
    * dancex11/scheduler/deployment_default_wait_strategy.h:
    * dancex11/scheduler/deployment_orb_wait_strategy.h:
    * dancex11/scheduler/events/plugin_manager.h:
    * tools/artifact_installation/dance_artifact_installation_handler.h:
    * tools/artifact_installation/installation_repository_manager.h:
    * tools/config_handlers/config_xml_typedefs.h:
    * tools/config_handlers/xml_file_intf.h:
    * tools/split_plan/locality_splitter.h:
    * tools/split_plan/node_splitter.h: