### PR TITLE
Give an error when the amount of processes is zero, could be that the…

### DIFF
--- a/tests/locality_manager/in_process/check_lm.sh
+++ b/tests/locality_manager/in_process/check_lm.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 cmd_output1=$(ps ax | grep "dancex11_deployment_manager.*dancex11_locality_dm_handler")
-cmd_output=$(echo "$cmd_output1" | grep -c "dancex11_deployment_manager.*-n.*LocalityInstance") 
+cmd_output=$(echo "$cmd_output1" | grep -c "dancex11_deployment_manager.*-n.*LocalityInstance")
 
 if [ "$cmd_output" == "0" ] ; then
   echo "Success!  The NM have been contacted and no LM have been spawned.";
-  
+
   rc=0
-  
+
   cmd_output=$(ps auxc | grep NM_with_inproce | wc -l)
-  
-  if [ "$cmd_output" -ne "1" ] ; then
+
+  if [ "$cmd_output" -eq "0" ] ; then
       echo "ERROR: Process name does not appear to have changed."
       echo "Process listing:"
       ps auxc
@@ -18,7 +18,7 @@ if [ "$cmd_output" == "0" ] ; then
   else
     echo "Success!  NM Process name appears to have been changed appropriately.";
   fi
-  
+
   exit $rc
 else
   echo "ERROR: Unexpected number of LM processes detected:"

--- a/tests/locality_manager/in_process/run_test.pl
+++ b/tests/locality_manager/in_process/run_test.pl
@@ -105,6 +105,7 @@ sub kill_open_processes {
     }
     # in case shutdown did not perform as expected
     $tg_daemon->KillAll ('dancex11_deployment_manager');
+    $tg_daemon->KillAll ('NM_with_inprocess_LM');
 }
 
 sub run_node_daemon {

--- a/tests/locality_manager/process_name/check_process_name.sh
+++ b/tests/locality_manager/process_name/check_process_name.sh
@@ -2,7 +2,7 @@
 
 cmd_output=$(ps auxc | grep newlocality_tes | wc -l)
 
-if [ "$cmd_output" -ne "1" ] ; then
+if [ "$cmd_output" -eq "0" ] ; then
     echo "ERROR: Process name does not appear to have changed."
     echo "Process listing:"
     ps auxc

--- a/tests/locality_manager/process_name/run_test.pl
+++ b/tests/locality_manager/process_name/run_test.pl
@@ -105,6 +105,7 @@ sub kill_open_processes {
     }
     # in case shutdown did not perform as expected
     $tg_daemon->KillAll ('dancex11_deployment_manager');
+    $tg_daemon->KillAll ('newlocality_test');
 }
 
 sub run_node_daemon {

--- a/tests/locality_manager/process_name/run_test_snl.pl
+++ b/tests/locality_manager/process_name/run_test_snl.pl
@@ -77,6 +77,7 @@ sub kill_open_processes {
     # in case shutdown did not perform as expected
     for ($i = 0; $i < $nr_daemon; ++$i) {
       $tg_daemons[$i]->KillAll ('dancex11_deployment_manager');
+      $tg_daemons[$i]->KillAll ('newlocality_test');
     }
 }
 


### PR DESCRIPTION
…re is a defunct process with the same name, also kill possible processes with the optional name

    * tests/locality_manager/in_process/check_lm.sh:
    * tests/locality_manager/in_process/run_test.pl:
    * tests/locality_manager/process_name/check_process_name.sh:
    * tests/locality_manager/process_name/run_test.pl:
    * tests/locality_manager/process_name/run_test_snl.pl: