### PR TITLE
Make use of std::exception logging

### DIFF
--- a/dancex11/deployment_manager/deployment_manager_exec.cpp
+++ b/dancex11/deployment_manager/deployment_manager_exec.cpp
@@ -48,7 +48,7 @@ main (int argc, char *argv[])
   }
   catch (const std::exception& ex)
   {
-    DANCEX11_LOG_PANIC ("DeploymentManager - Error, std::exception: " << ex.what ());
+    DANCEX11_LOG_PANIC ("DeploymentManager - Error, std::exception: " << ex);
     retval = 1;
   }
   catch (...)

--- a/dancex11/plan_launcher/plan_launcher_exec.cpp
+++ b/dancex11/plan_launcher/plan_launcher_exec.cpp
@@ -48,7 +48,7 @@ main (int argc, char *argv[])
   }
   catch (const std::exception& ex)
   {
-    DANCEX11_LOG_PANIC ("PlanLauncher - Error, std::exception: " << ex.what ());
+    DANCEX11_LOG_PANIC ("PlanLauncher - Error, std::exception: " << ex);
     retval = 1;
   }
   catch (...)

--- a/dancex11/scheduler/events/plugin_manager.cpp
+++ b/dancex11/scheduler/events/plugin_manager.cpp
@@ -223,16 +223,14 @@ namespace DAnCEX11
         DANCEX11_LOG_ERROR ("Plugin_Manager::register_installation_handler - " <<
                             "CORBA Exception caught while loading artifact <" << artifact <<
                             ">:<" << entrypoint << "> - " << err.str ());
-        throw ::Deployment::PlanError (artifact,
-                                       err.str ());
+        throw ::Deployment::PlanError (artifact, err.str ());
       }
     catch (const std::exception& ex)
       {
         DANCEX11_LOG_ERROR ("Plugin_Manager::register_installation_handler - "
                             "STD C++ exception while configuring plugin from <" << artifact <<
-                            ">:<" << entrypoint << "> -" << ex.what ());
-        throw ::Deployment::PlanError (artifact,
-                                       ex.what ());
+                            ">:<" << entrypoint << "> -" << ex);
+        throw ::Deployment::PlanError (artifact, ex.what ());
       }
     catch (...)
       {

--- a/tests/log_test/log_test.cpp
+++ b/tests/log_test/log_test.cpp
@@ -209,7 +209,7 @@ int main(int /*argc*/, char** /*argv[]*/)
   }
   catch (const std::exception& e)
   {
-    dancex11_error << "exception caught: " << e.what () << std::endl;
+    dancex11_error << "exception caught: " << e << std::endl;
     return 1;
   }
   return 0;

--- a/tests/log_test_env/log_test.cpp
+++ b/tests/log_test_env/log_test.cpp
@@ -90,7 +90,7 @@ int main(int /*argc*/, char** /*argv[]*/)
   }
   catch (const std::exception& e)
   {
-    dancex11_error << "exception caught: " << e.what () << std::endl;
+    dancex11_error << "exception caught: " << e << std::endl;
     return 1;
   }
   return 0;

--- a/tools/config_handlers/xml_file_intf.cpp
+++ b/tools/config_handlers/xml_file_intf.cpp
@@ -153,7 +153,7 @@ namespace DAnCEX11
       {
          DANCEX11_LOG_ERROR ("XML_File_Intf::caught - CORBA Exception while parsing XML into IDL"
                              << ex);
-         throw Config_Error (this->file_, ex.what());
+         throw Config_Error (this->file_, ex.what ());
       }
       catch (const Config_Error &ex)
       {


### PR DESCRIPTION
    * dancex11/deployment_manager/deployment_manager_exec.cpp:
    * dancex11/plan_launcher/plan_launcher_exec.cpp:
    * dancex11/scheduler/events/plugin_manager.cpp:
    * tests/log_test/log_test.cpp:
    * tests/log_test_env/log_test.cpp:
    * tools/config_handlers/xml_file_intf.cpp: