### PR TITLE
Use override for destructors, use default

### DIFF
--- a/dancex11/configurator/dancex11_config_parser.h
+++ b/dancex11/configurator/dancex11_config_parser.h
@@ -165,7 +165,7 @@ namespace DAnCEX11
     Config_Parser_T(Args&& ...args)
       : stream_ (std::forward<Args> (args)...)
     { }
-    virtual ~Config_Parser_T () = default;
+    ~Config_Parser_T () override = default;
 
   protected:
     typename base_type::stream_base_type& stream () const override

--- a/dancex11/configurator/dancex11_config_stream.h
+++ b/dancex11/configurator/dancex11_config_stream.h
@@ -87,7 +87,7 @@ namespace DAnCEX11
         source_ (std::forward<Args> (args)...)
     { this->source_ >> std::skipws; }
 
-    virtual ~Config_Stream_T () = default;
+    ~Config_Stream_T () override = default;
 
   protected:
     typename base::source_type& source () const override

--- a/dancex11/core/dancex11_deployment_cdr_plan_loader.h
+++ b/dancex11/core/dancex11_deployment_cdr_plan_loader.h
@@ -24,7 +24,7 @@ namespace DAnCEX11
     : public Plan_Loader_base
   {
   public:
-    virtual ~CDRPlan_Loader () = default;
+    ~CDRPlan_Loader () override = default;
 
     bool read_plan (const std::string& filename,
                     Deployment::DeploymentPlan& plan) override;
@@ -42,7 +42,7 @@ namespace DAnCEX11
     : public ACE_Service_Object
   {
   public:
-    virtual ~CDRPlan_Loader_Svc ();
+    ~CDRPlan_Loader_Svc () override;
 
     /// Initializes object when dynamic linking occurs.
     int init (int argc, ACE_TCHAR *argv[]) override;

--- a/dancex11/core/dancex11_deployment_config_plan_loader.h
+++ b/dancex11/core/dancex11_deployment_config_plan_loader.h
@@ -24,7 +24,7 @@ namespace DAnCEX11
     : public Plan_Loader_base
   {
   public:
-    virtual ~CFGPlan_Loader () = default;
+    ~CFGPlan_Loader () override = default;
 
     bool read_plan (const std::string& filename,
                     Deployment::DeploymentPlan& plan) override;

--- a/dancex11/core/dancex11_deploymentinterceptors_base_impl.h
+++ b/dancex11/core/dancex11_deploymentinterceptors_base_impl.h
@@ -25,7 +25,7 @@ namespace DAnCEX11
   public:
     DeploymentInterceptor_Base ();
 
-    virtual ~DeploymentInterceptor_Base ();
+    ~DeploymentInterceptor_Base () override;
 
     void configure (const Deployment::Properties & config) override;
 

--- a/dancex11/core/dancex11_dmh_loader.h
+++ b/dancex11/core/dancex11_dmh_loader.h
@@ -28,7 +28,7 @@ namespace DAnCEX11
   {
   public:
     /// The destructor
-    virtual ~DMHandler_Loader ();
+    ~DMHandler_Loader () override;
 
     /**
      * Create and activate an DMH instance.

--- a/dancex11/domain_deployment_handler/dancex11_ddh_application_impl.cpp
+++ b/dancex11/domain_deployment_handler/dancex11_ddh_application_impl.cpp
@@ -53,7 +53,7 @@ namespace DAnCEX11
                       IDL::traits<Deployment::NodeApplicationManager>::ref_type nam,
                       std::string node)
      : poa_ (std::move(poa)), nam_ (std::move(nam)), node_ (std::move(node)) {}
-    virtual ~NAM_ReplyHandler () = default;
+    ~NAM_ReplyHandler () override = default;
 
     future_type& result () { return this->result_; }
 
@@ -209,7 +209,7 @@ namespace DAnCEX11
     NA_ReplyHandler (IDL::traits<PortableServer::POA>::ref_type poa,
                      std::string node)
      : poa_ (std::move(poa)), node_ (std::move(node)) {}
-    virtual ~NA_ReplyHandler () = default;
+    ~NA_ReplyHandler () override = default;
 
     future_type& result () { return this->result_; }
 

--- a/dancex11/domain_deployment_handler/dancex11_ddh_application_impl.h
+++ b/dancex11/domain_deployment_handler/dancex11_ddh_application_impl.h
@@ -28,7 +28,6 @@ namespace DAnCEX11
   : public virtual CORBA::servant_traits< ::Deployment::DomainApplication>::base_type
     {
     public:
-
       using TNm2Id_PAIR = std::pair <IDL::traits< ::Deployment::NodeManager>::ref_type , std::string>;
       using TNam2Nm_PAIR = std::pair <IDL::traits< ::Deployment::NodeApplicationManager>::ref_type,IDL::traits< ::Deployment::NodeManager>::ref_type>;
       using TApp2Mgr_PAIR = std::pair <IDL::traits< ::Deployment::Application>::ref_type, IDL::traits< ::Deployment::NodeApplicationManager>::ref_type>;
@@ -44,7 +43,7 @@ namespace DAnCEX11
                               TNam2Nm& nams,
                               TNm2Id& node_ids);
 
-      virtual ~DomainApplication_Impl();
+      ~DomainApplication_Impl() override;
 
       void startLaunch (const ::Deployment::Properties & configProperty,
                         ::Deployment::Connections& providedReference);

--- a/dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.cpp
+++ b/dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.cpp
@@ -53,7 +53,7 @@ namespace DAnCEX11
                               std::string node)
      : poa_ (std::move(poa)), nm_ (std::move(nm)), node_ (std::move(node)) {}
 
-    virtual ~NodeManager_ReplyHandler () = default;
+    ~NodeManager_ReplyHandler () override = default;
 
     future_type& result () { return this->result_; }
 

--- a/dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.h
+++ b/dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.h
@@ -34,7 +34,7 @@ namespace DAnCEX11
                                      ::Deployment::DeploymentPlan plan,
                                      Node_Locator &nodes);
 
-      virtual ~DomainApplicationManager_Impl();
+      ~DomainApplicationManager_Impl() override;
 
       IDL::traits< ::Deployment::Application>::ref_type
       startLaunch (const ::Deployment::Properties& configProperty,

--- a/dancex11/domain_deployment_handler/dancex11_domain_deployment_handler.cpp
+++ b/dancex11/domain_deployment_handler/dancex11_domain_deployment_handler.cpp
@@ -52,19 +52,15 @@ namespace DAnCEX11
         plugins_ (std::move(plugins)),
         sh_ (std::move(sh))
     {}
-    virtual ~Domain_Launcher () = default;
+    ~Domain_Launcher () override = default;
 
-    Deployment::DeploymentPlan
-    plan() override;
+    Deployment::DeploymentPlan plan() override;
 
-    void
-    plan (const Deployment::DeploymentPlan& _v) override;
+    void plan (const Deployment::DeploymentPlan& _v) override;
 
-    void
-    launch () override;
+    void launch () override;
 
-    void
-    shutdown () override;
+    void shutdown () override;
 
   private:
     Deployment::DeploymentPlan plan_;

--- a/dancex11/domain_deployment_handler/dancex11_domain_dmh_loader.h
+++ b/dancex11/domain_deployment_handler/dancex11_domain_dmh_loader.h
@@ -23,7 +23,7 @@ namespace DAnCEX11
   {
   public:
     /// The destructor
-    virtual ~Domain_DMHandler_Loader () = default;
+    ~Domain_DMHandler_Loader () override = default;
 
     /// Initializes handler on dynamic loading.
     int init (int argc, ACE_TCHAR *argv[]) override;

--- a/dancex11/domain_deployment_handler/dancex11_execution_manager_impl.h
+++ b/dancex11/domain_deployment_handler/dancex11_execution_manager_impl.h
@@ -26,7 +26,7 @@ namespace DAnCEX11
                              std::string nc,
                              IDL::traits< ::DAnCEX11::ShutdownHandler>::ref_type sh);
 
-      virtual ~ExecutionManager_Impl ();
+      ~ExecutionManager_Impl () override;
 
       IDL::traits< ::Deployment::ApplicationManager>::ref_type
       preparePlan (const ::Deployment::DeploymentPlan& plan,

--- a/dancex11/handler/configuration/cpu_affinity.h
+++ b/dancex11/handler/configuration/cpu_affinity.h
@@ -25,7 +25,7 @@ namespace DAnCEX11
   public:
     CPU_Affinity () = default;
 
-    virtual ~CPU_Affinity () = default;
+    ~CPU_Affinity () override = default;
 
     std::string type () override;
 

--- a/dancex11/handler/configuration/process_name.h
+++ b/dancex11/handler/configuration/process_name.h
@@ -27,7 +27,7 @@ namespace DAnCEX11
     Process_Name () = default;
 
     // Destructor
-    virtual ~Process_Name () = default;
+    ~Process_Name () override = default;
 
     std::string type () override;
 

--- a/dancex11/handler/configuration/process_priority.h
+++ b/dancex11/handler/configuration/process_priority.h
@@ -27,7 +27,7 @@ namespace DAnCEX11
     Process_Priority () = default;
 
     // Destructor
-    virtual ~Process_Priority () = default;
+    ~Process_Priority () override = default;
 
     std::string type () override;
 

--- a/dancex11/handler/instance/artifact_deployment_handler.h
+++ b/dancex11/handler/instance/artifact_deployment_handler.h
@@ -27,7 +27,7 @@ namespace DAnCEX11
     Artifact_Deployment_Handler_i ();
 
     // Destructor
-    virtual ~Artifact_Deployment_Handler_i ();
+    ~Artifact_Deployment_Handler_i () override;
 
     std::string instance_type () override;
 
@@ -78,7 +78,7 @@ namespace DAnCEX11
   public:
     Artifact_Deployment_Initializer () = default;
 
-    virtual ~Artifact_Deployment_Initializer ();
+    ~Artifact_Deployment_Initializer () override;
 
     void preprocess_plan (Deployment::DeploymentPlan & plan) override;
   };

--- a/dancex11/handler/instance/config_handler_impl.h
+++ b/dancex11/handler/instance/config_handler_impl.h
@@ -23,7 +23,7 @@ namespace DAnCEX11
   public:
     Config_Handler_Impl (Plugin_Manager&);
 
-    virtual ~Config_Handler_Impl ();
+    ~Config_Handler_Impl () override;
 
     std::string instance_type () override;
 

--- a/dancex11/handler/instance/inst_handler_impl.h
+++ b/dancex11/handler/instance/inst_handler_impl.h
@@ -23,7 +23,7 @@ namespace DAnCEX11
   public:
     Inst_Handler_Impl (Plugin_Manager&);
 
-    virtual ~Inst_Handler_Impl () = default;
+    ~Inst_Handler_Impl () override = default;
 
     std::string instance_type () override;
 

--- a/dancex11/handler/instance/interceptor_handler_impl.h
+++ b/dancex11/handler/instance/interceptor_handler_impl.h
@@ -25,7 +25,7 @@ namespace DAnCEX11
   public:
     Interceptor_Handler_Impl (Plugin_Manager&);
 
-    virtual ~Interceptor_Handler_Impl ();
+    ~Interceptor_Handler_Impl () override;
 
     std::string instance_type () override;
 

--- a/dancex11/handler/instance/locality_activator_impl.h
+++ b/dancex11/handler/instance/locality_activator_impl.h
@@ -50,7 +50,7 @@ namespace DAnCEX11
                                IDL::traits<PortableServer::POA>::ref_type poa_);
 
     /// Destructor
-    virtual ~DAnCE_LocalityActivator_i ();
+    ~DAnCE_LocalityActivator_i () override;
 
     void locality_manager_callback (
         IDL::traits< ::DAnCEX11::LocalityManager>::ref_type serverref,
@@ -148,7 +148,7 @@ namespace DAnCEX11
     {
     public:
       Server_Child_Handler (Safe_Server_Info  si);
-      virtual ~Server_Child_Handler ();
+      ~Server_Child_Handler () override;
 
       int handle_close (ACE_HANDLE, ACE_Reactor_Mask) override;
 

--- a/dancex11/handler/instance/locality_manager_handler_impl.h
+++ b/dancex11/handler/instance/locality_manager_handler_impl.h
@@ -28,7 +28,7 @@ namespace DAnCEX11
     Locality_Handler_i ();
 
     // Destructor
-    virtual ~Locality_Handler_i ();
+    ~Locality_Handler_i () override;
 
     std::string instance_type () override;
 

--- a/dancex11/handler/instance/service_object_handler_impl.h
+++ b/dancex11/handler/instance/service_object_handler_impl.h
@@ -23,7 +23,7 @@ namespace DAnCEX11
   public:
     Service_Object_Handler_Impl (Plugin_Manager&);
 
-    virtual ~Service_Object_Handler_Impl () = default;
+    ~Service_Object_Handler_Impl () override = default;
 
     std::string instance_type () override;
 

--- a/dancex11/handler/interceptors/best_effort.h
+++ b/dancex11/handler/interceptors/best_effort.h
@@ -22,7 +22,7 @@ namespace DAnCEX11
   public:
     Best_Effort () = default;
 
-    virtual ~Best_Effort ();
+    ~Best_Effort () override;
 
     void
     post_install (const Deployment::DeploymentPlan &plan,

--- a/dancex11/handler/interceptors/standard_error.h
+++ b/dancex11/handler/interceptors/standard_error.h
@@ -22,7 +22,7 @@ namespace DAnCEX11
   public:
     Standard_Error () = default;
 
-    virtual ~Standard_Error ();
+    ~Standard_Error () override;
 
     void
     post_install (const Deployment::DeploymentPlan &plan,

--- a/dancex11/locality_deployment_handler/dancex11_locality_deployment_handler.cpp
+++ b/dancex11/locality_deployment_handler/dancex11_locality_deployment_handler.cpp
@@ -46,10 +46,9 @@ namespace DAnCEX11
         plugins_ (std::move(plugins)),
         sh_ (std::move(sh))
     {}
-    virtual ~Locality_Launcher () = default;
+    ~Locality_Launcher () override = default;
 
-    Deployment::DeploymentPlan
-    plan() override;
+    Deployment::DeploymentPlan plan() override;
 
     void plan (const Deployment::DeploymentPlan& _v) override;
 

--- a/dancex11/locality_deployment_handler/dancex11_locality_dmh_loader.h
+++ b/dancex11/locality_deployment_handler/dancex11_locality_dmh_loader.h
@@ -23,7 +23,7 @@ namespace DAnCEX11
   {
   public:
     /// The destructor
-    virtual ~Locality_DMHandler_Loader ();
+    ~Locality_DMHandler_Loader () override;
 
     /// Initializes handler on dynamic loading.
     int init (int argc, ACE_TCHAR *argv[]) override;

--- a/dancex11/locality_deployment_handler/dancex11_locality_manager_impl.h
+++ b/dancex11/locality_deployment_handler/dancex11_locality_manager_impl.h
@@ -35,7 +35,7 @@ namespace DAnCEX11
       IDL::traits<PortableServer::POA>::ref_type poa,
       IDL::traits< ::DAnCEX11::ShutdownHandler>::ref_type sh);
 
-    virtual ~LocalityManager_i ();
+    ~LocalityManager_i () override;
 
     void
     configure (const Deployment::Properties &prop) override;

--- a/dancex11/node_deployment_handler/dancex11_ndh_application_impl.h
+++ b/dancex11/node_deployment_handler/dancex11_ndh_application_impl.h
@@ -40,7 +40,7 @@ namespace DAnCEX11
                           std::string node_name,
                           Plugin_Event_Scheduler_T<Deployment_Scheduler> &scheduler);
 
-    virtual ~NodeApplication_Impl();
+    ~NodeApplication_Impl() override;
 
     void finishLaunch (const ::Deployment::Connections & providedReference,
                        bool start) override;

--- a/dancex11/node_deployment_handler/dancex11_ndh_application_manager_impl.h
+++ b/dancex11/node_deployment_handler/dancex11_ndh_application_manager_impl.h
@@ -31,7 +31,7 @@ namespace DAnCEX11
                                  std::string domain_nc,
                                  std::shared_ptr<Plugin_Manager> plugins);
 
-    virtual ~NodeApplicationManager_Impl();
+    ~NodeApplicationManager_Impl() override;
 
     IDL::traits<Deployment::Application>::ref_type
     startLaunch (const Deployment::Properties & configProperty,

--- a/dancex11/node_deployment_handler/dancex11_ndh_manager_impl.h
+++ b/dancex11/node_deployment_handler/dancex11_ndh_manager_impl.h
@@ -30,7 +30,7 @@ namespace DAnCEX11
                       std::shared_ptr<Plugin_Manager> plugins,
                       IDL::traits< ::DAnCEX11::ShutdownHandler>::ref_type sh);
 
-    virtual ~NodeManager_Impl();
+    ~NodeManager_Impl() override;
 
     void joinDomain (const ::Deployment::Domain & theDomain,
                      IDL::traits< ::Deployment::TargetManager>::ref_type manager,

--- a/dancex11/node_deployment_handler/dancex11_node_deployment_handler.cpp
+++ b/dancex11/node_deployment_handler/dancex11_node_deployment_handler.cpp
@@ -44,7 +44,7 @@ namespace DAnCEX11
         plugins_ (std::move(plugins)),
         sh_ (std::move(sh))
     {}
-    virtual ~Node_Launcher () = default;
+    ~Node_Launcher () override = default;
 
     Deployment::DeploymentPlan plan() override;
 

--- a/dancex11/node_deployment_handler/dancex11_node_deployment_handler.h
+++ b/dancex11/node_deployment_handler/dancex11_node_deployment_handler.h
@@ -26,7 +26,7 @@ namespace DAnCEX11
   {
   public:
     NodeDeploymentHandler () = default;
-    virtual ~NodeDeploymentHandler () = default;
+    ~NodeDeploymentHandler () override = default;
 
     std::string handler_type() override;
 

--- a/dancex11/node_deployment_handler/dancex11_node_dmh_loader.h
+++ b/dancex11/node_deployment_handler/dancex11_node_dmh_loader.h
@@ -23,7 +23,7 @@ namespace DAnCEX11
   {
   public:
     /// The destructor
-    virtual ~Node_DMHandler_Loader ();
+    ~Node_DMHandler_Loader () override;
 
     /**
      * Create and activate an DMH instance.

--- a/dancex11/plan_launcher/launcher_impl.h
+++ b/dancex11/plan_launcher/launcher_impl.h
@@ -27,11 +27,9 @@ namespace DAnCEX11
     {}
     virtual ~Launcher_Base () = default;
 
-    bool
-    launch_plan (IDL::traits<Deployment::Deployment_Manager>::ref_type);
+    bool launch_plan (IDL::traits<Deployment::Deployment_Manager>::ref_type);
 
-    bool
-    teardown_plan (IDL::traits<Deployment::Deployment_Manager>::ref_type);
+    bool teardown_plan (IDL::traits<Deployment::Deployment_Manager>::ref_type);
 
   protected:
     virtual IDL::traits<Deployment::ApplicationManager>::ref_type

--- a/dancex11/scheduler/completion_base.h
+++ b/dancex11/scheduler/completion_base.h
@@ -50,7 +50,7 @@ namespace DAnCEX11
     {
     }
 
-    virtual ~Completion_T () = default;
+    ~Completion_T () override = default;
 
     void
     update (const future_type &future) override

--- a/dancex11/scheduler/deployment_scheduler.h
+++ b/dancex11/scheduler/deployment_scheduler.h
@@ -18,7 +18,7 @@ namespace DAnCEX11
   {
   public:
     Deployment_Scheduler () = default;
-    virtual ~Deployment_Scheduler () = default;
+    ~Deployment_Scheduler () override = default;
 
     /// Schedule an event for execution
     int schedule_event (Deployment_Event *event);

--- a/dancex11/scheduler/events/action_base.h
+++ b/dancex11/scheduler/events/action_base.h
@@ -26,7 +26,7 @@ namespace DAnCEX11
         const std::string &name,
         const std::string &instance_type);
 
-    virtual ~Action_Base () = default;
+    ~Action_Base () override = default;
 
     int call () override;
 

--- a/dancex11/scheduler/events/configured.h
+++ b/dancex11/scheduler/events/configured.h
@@ -29,7 +29,7 @@ namespace DAnCEX11
         const std::string &inst_type,
         Event_Future holder);
 
-    virtual ~Instance_Configured ()= default;
+    ~Instance_Configured () override = default;
 
     //@{
     /** Illegal to be called. Deleted explicitly to let the compiler detect any violation */

--- a/dancex11/scheduler/events/connect.h
+++ b/dancex11/scheduler/events/connect.h
@@ -30,7 +30,7 @@ namespace DAnCEX11
         const std::string &instance_type,
         Event_Future holder);
 
-    virtual ~Connect_Instance () = default;
+    ~Connect_Instance () override = default;
 
     //@{
     /** Illegal to be called. Deleted explicitly to let the compiler detect any violation */

--- a/dancex11/scheduler/events/disconnect.h
+++ b/dancex11/scheduler/events/disconnect.h
@@ -29,7 +29,7 @@ namespace DAnCEX11
         const std::string &inst_type,
         Event_Future holder);
 
-    virtual ~Disconnect_Instance () = default;
+    ~Disconnect_Instance () override = default;
 
     //@{
     /** Illegal to be called. Deleted explicitly to let the compiler detect any violation */

--- a/dancex11/scheduler/events/endpoint.h
+++ b/dancex11/scheduler/events/endpoint.h
@@ -29,7 +29,7 @@ namespace DAnCEX11
         const std::string &inst_type,
         Event_Future holder);
 
-    virtual ~Endpoint_Reference () = default;
+    ~Endpoint_Reference () override = default;
 
     //@{
     /** Illegal to be called. Deleted explicitly to let the compiler detect any violation */

--- a/dancex11/scheduler/events/install.h
+++ b/dancex11/scheduler/events/install.h
@@ -29,7 +29,7 @@ namespace DAnCEX11
         const std::string &instance_type,
         Event_Future holder);
 
-    virtual ~Install_Instance () = default;
+    ~Install_Instance () override = default;
 
   protected:
     void invoke_pre_interceptor (IDL::traits<DAnCEX11::DeploymentInterceptor>::ref_type) override;

--- a/dancex11/scheduler/events/passivate.h
+++ b/dancex11/scheduler/events/passivate.h
@@ -29,7 +29,7 @@ namespace DAnCEX11
         const std::string &inst_type,
         Event_Future holder);
 
-    virtual ~Passivate_Instance () = default;
+    ~Passivate_Instance () override = default;
 
   protected:
     void invoke_pre_interceptor (IDL::traits<DAnCEX11::DeploymentInterceptor>::ref_type) override;

--- a/dancex11/scheduler/events/remove.h
+++ b/dancex11/scheduler/events/remove.h
@@ -29,7 +29,7 @@ namespace DAnCEX11
         const std::string &instance_type,
         Event_Future holder);
 
-    virtual ~Remove_Instance () = default;
+    ~Remove_Instance () override = default;
 
     //@{
     /** Illegal to be called. Deleted explicitly to let the compiler detect any violation */

--- a/dancex11/scheduler/events/start.h
+++ b/dancex11/scheduler/events/start.h
@@ -29,7 +29,7 @@ namespace DAnCEX11
         const std::string &inst_type,
         Event_Future holder);
 
-    virtual ~Start_Instance () = default;
+    ~Start_Instance () override = default;
 
     //@{
     /** Illegal to be called. Deleted explicitly to let the compiler detect any violation */

--- a/tools/artifact_installation/artifact_installation_handler_svc.h
+++ b/tools/artifact_installation/artifact_installation_handler_svc.h
@@ -21,7 +21,7 @@ namespace DAnCEX11
       {
         public:
           ArtifactInstallationHandlerSvc () = default;
-          virtual ~ArtifactInstallationHandlerSvc () = default;
+          ~ArtifactInstallationHandlerSvc () override = default;
 
           /// Initialization hook.
           int init (int argc, ACE_TCHAR *argv[]) override;

--- a/tools/artifact_installation/artifact_installation_impl.h
+++ b/tools/artifact_installation/artifact_installation_impl.h
@@ -85,14 +85,13 @@ namespace DAnCEX11
       using TLOCK = ACE_MT_SYNCH::MUTEX ;
       using TCONDITION = ACE_MT_SYNCH::CONDITION;
       using TPropertyMap = ArtifactInstallationHandler::TPropertyMap;
-      virtual ~ArtifactInstallation_Impl ();
+      ~ArtifactInstallation_Impl () override;
 
       void initialize () override;
 
       void clear () override;
 
-      void prepare (
-          const ::Deployment::DeploymentPlan& plan) override;
+      void prepare (const ::Deployment::DeploymentPlan& plan) override;
 
       void install (const std::string& plan_uuid,
             const ::Deployment::ArtifactDeploymentDescription & artifact) override;

--- a/tools/artifact_installation/dance_artifact_installation_handler.h
+++ b/tools/artifact_installation/dance_artifact_installation_handler.h
@@ -19,8 +19,7 @@ namespace DAnCEX11
   class DAnCE_Artifact_Installation_Export ArtifactInstallationHandler
   {
     public:
-      typedef std::map<std::string,
-                       std::string> TPropertyMap;
+      using TPropertyMap = std::map<std::string, std::string>;
 
       virtual ~ArtifactInstallationHandler () = default;
 

--- a/tools/artifact_installation/file_installation_handler.h
+++ b/tools/artifact_installation/file_installation_handler.h
@@ -21,7 +21,7 @@ namespace DAnCEX11
         public:
           static const std::string protocol;
 
-          virtual ~FileInstallationHandler () = default;
+          ~FileInstallationHandler () override = default;
 
           const std::string& protocol_prefix () override;
 
@@ -46,7 +46,7 @@ namespace DAnCEX11
       {
         public:
           FileInstallationHandlerSvc () = default;
-          virtual ~FileInstallationHandlerSvc () = default;
+          ~FileInstallationHandlerSvc () override = default;
 
           ArtifactInstallationHandler* handler_instance () override;
 

--- a/tools/artifact_installation/http_installation_handler.cpp
+++ b/tools/artifact_installation/http_installation_handler.cpp
@@ -22,7 +22,7 @@ namespace DAnCEX11
     public:
       HTTPInstallationRequestHandler (const ACE_CString& plan_uuid)
         : plan_uuid_ (plan_uuid) {}
-      virtual ~HTTPInstallationRequestHandler () = default;
+      ~HTTPInstallationRequestHandler () override = default;
 
     protected:
       virtual void handle_response (const ACE::HTTP::URL& url, const ACE::HTTP::Response& response)

--- a/tools/artifact_installation/http_installation_handler.h
+++ b/tools/artifact_installation/http_installation_handler.h
@@ -21,7 +21,7 @@ namespace DAnCEX11
         public:
           static const std::string protocol;
 
-          virtual ~HttpInstallationHandler () = default;
+          ~HttpInstallationHandler () override = default;
 
           const std::string& protocol_prefix () override;
 
@@ -47,7 +47,7 @@ namespace DAnCEX11
       {
         public:
           HttpInstallationHandlerSvc () = default;
-          virtual ~HttpInstallationHandlerSvc () = default;
+          ~HttpInstallationHandlerSvc () override = default;
 
           ArtifactInstallationHandler* handler_instance () override;
 

--- a/tools/artifact_installation/installation_repository_manager.h
+++ b/tools/artifact_installation/installation_repository_manager.h
@@ -78,7 +78,7 @@ namespace DAnCEX11
       {
         public:
           InstallationRepositoryManagerSvc () = default;
-          virtual ~InstallationRepositoryManagerSvc () = default;
+          ~InstallationRepositoryManagerSvc () override = default;
 
           /// Initialization hook.
           int init (int argc, ACE_TCHAR *argv[]) override;

--- a/tools/artifact_installation/installation_repository_manager_impl.h
+++ b/tools/artifact_installation/installation_repository_manager_impl.h
@@ -20,7 +20,7 @@ namespace DAnCEX11
     : public InstallationRepository
   {
   public:
-    virtual ~InstallationRepository_Impl () = default;
+    ~InstallationRepository_Impl () override = default;
 
     const std::string& plan () override;
 
@@ -65,7 +65,7 @@ namespace DAnCEX11
       private InstallationRepository_Impl
   {
   public:
-    virtual ~InstallationRepositoryManager_Impl () = default;
+    ~InstallationRepositoryManager_Impl () override = default;
 
     void map_repository (const std::string& plan,
                          const std::string& folder) override;
@@ -94,7 +94,7 @@ namespace DAnCEX11
   {
   public:
     InstallationRepositoryManagerSvc_Impl () = default;
-    virtual ~InstallationRepositoryManagerSvc_Impl () = default;
+    ~InstallationRepositoryManagerSvc_Impl () override = default;
 
     /// Initializes handler on dynamic loading.
     int init (int argc, ACE_TCHAR *argv[]) override;

--- a/tools/config_handlers/dancex11_deployment_cdp_plan_loader.h
+++ b/tools/config_handlers/dancex11_deployment_cdp_plan_loader.h
@@ -23,7 +23,7 @@ namespace DAnCEX11
     : public Plan_Loader_base
   {
   public:
-    virtual ~CDPPlan_Loader () = default;
+    ~CDPPlan_Loader () override = default;
 
     bool read_plan (const std::string& filename,
                     Deployment::DeploymentPlan& plan) override;
@@ -41,7 +41,7 @@ namespace DAnCEX11
     : public ACE_Service_Object
   {
   public:
-    virtual ~CDPPlan_Loader_Svc ();
+    ~CDPPlan_Loader_Svc () override;
 
     /// Initializes object when dynamic linking occurs.
     int init (int argc, ACE_TCHAR *argv[]) override;
@@ -54,7 +54,6 @@ namespace DAnCEX11
 
   ACE_STATIC_SVC_DECLARE (CDPPlan_Loader_Svc)
   ACE_FACTORY_DECLARE (Config_Handlers, CDPPlan_Loader_Svc)
-
 };
 
 #endif /* DANCEX11_DEPLOYMENT_CDP_PLAN_LOADER_H */

--- a/tools/split_plan/sub_uuid_generator.cpp
+++ b/tools/split_plan/sub_uuid_generator.cpp
@@ -11,10 +11,6 @@
 
 namespace DAnCEX11
 {
-  Unique_Sub_UUID_Generator::Unique_Sub_UUID_Generator ()
-    {
-    }
-
   void Unique_Sub_UUID_Generator::generate_sub_uuid (
       const Deployment::DeploymentPlan &parent_plan,
       Deployment::DeploymentPlan &sub_plan,
@@ -23,10 +19,6 @@ namespace DAnCEX11
       std::ostringstream sub_uuid_str;
       sub_uuid_str << parent_plan.UUID () << "_" << sub_plan_index;
       sub_plan.UUID (sub_uuid_str.str ());
-    }
-
-  Copy_UUID_Generator::Copy_UUID_Generator ()
-    {
     }
 
   void Copy_UUID_Generator::generate_sub_uuid (

--- a/tools/split_plan/sub_uuid_generator.h
+++ b/tools/split_plan/sub_uuid_generator.h
@@ -17,21 +17,23 @@ namespace DAnCEX11
   class DAnCE_Split_Plan_Export Copy_UUID_Generator
   {
   public:
-    Copy_UUID_Generator ();
+    Copy_UUID_Generator () = default;
+    ~Copy_UUID_Generator () = default;
 
-    void      generate_sub_uuid (const Deployment::DeploymentPlan &parent_plan,
-                                 Deployment::DeploymentPlan &sub_plan,
-                                 uint32_t sub_plan_index);
+    void generate_sub_uuid (const Deployment::DeploymentPlan &parent_plan,
+                            Deployment::DeploymentPlan &sub_plan,
+                            uint32_t sub_plan_index);
   };
 
   class DAnCE_Split_Plan_Export Unique_Sub_UUID_Generator
   {
   public:
-    Unique_Sub_UUID_Generator ();
+    Unique_Sub_UUID_Generator () = default;
+    ~Unique_Sub_UUID_Generator () = default;
 
-    void      generate_sub_uuid (const Deployment::DeploymentPlan &parent_plan,
-                                 Deployment::DeploymentPlan &sub_plan,
-                                 uint32_t sub_plan_index);
+    void generate_sub_uuid (const Deployment::DeploymentPlan &parent_plan,
+                            Deployment::DeploymentPlan &sub_plan,
+                            uint32_t sub_plan_index);
   };
 
 }


### PR DESCRIPTION
    * dancex11/configurator/dancex11_config_parser.h:
    * dancex11/configurator/dancex11_config_stream.h:
    * dancex11/core/dancex11_deployment_cdr_plan_loader.h:
    * dancex11/core/dancex11_deployment_config_plan_loader.h:
    * dancex11/core/dancex11_deploymentinterceptors_base_impl.h:
    * dancex11/core/dancex11_dmh_loader.h:
    * dancex11/domain_deployment_handler/dancex11_ddh_application_impl.cpp:
    * dancex11/domain_deployment_handler/dancex11_ddh_application_impl.h:
    * dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.cpp:
    * dancex11/domain_deployment_handler/dancex11_ddh_application_manager_impl.h:
    * dancex11/domain_deployment_handler/dancex11_domain_deployment_handler.cpp:
    * dancex11/domain_deployment_handler/dancex11_domain_dmh_loader.h:
    * dancex11/domain_deployment_handler/dancex11_execution_manager_impl.h:
    * dancex11/handler/configuration/cpu_affinity.h:
    * dancex11/handler/configuration/process_name.h:
    * dancex11/handler/configuration/process_priority.h:
    * dancex11/handler/instance/artifact_deployment_handler.h:
    * dancex11/handler/instance/config_handler_impl.h:
    * dancex11/handler/instance/inst_handler_impl.h:
    * dancex11/handler/instance/interceptor_handler_impl.h:
    * dancex11/handler/instance/locality_activator_impl.h:
    * dancex11/handler/instance/locality_manager_handler_impl.h:
    * dancex11/handler/instance/service_object_handler_impl.h:
    * dancex11/handler/interceptors/best_effort.h:
    * dancex11/handler/interceptors/standard_error.h:
    * dancex11/locality_deployment_handler/dancex11_locality_deployment_handler.cpp:
    * dancex11/locality_deployment_handler/dancex11_locality_dmh_loader.h:
    * dancex11/locality_deployment_handler/dancex11_locality_manager_impl.h:
    * dancex11/node_deployment_handler/dancex11_ndh_application_impl.h:
    * dancex11/node_deployment_handler/dancex11_ndh_application_manager_impl.h:
    * dancex11/node_deployment_handler/dancex11_ndh_manager_impl.h:
    * dancex11/node_deployment_handler/dancex11_node_deployment_handler.cpp:
    * dancex11/node_deployment_handler/dancex11_node_deployment_handler.h:
    * dancex11/node_deployment_handler/dancex11_node_dmh_loader.h:
    * dancex11/plan_launcher/launcher_impl.h:
    * dancex11/scheduler/completion_base.h:
    * dancex11/scheduler/deployment_scheduler.h:
    * dancex11/scheduler/events/action_base.h:
    * dancex11/scheduler/events/configured.h:
    * dancex11/scheduler/events/connect.h:
    * dancex11/scheduler/events/disconnect.h:
    * dancex11/scheduler/events/endpoint.h:
    * dancex11/scheduler/events/install.h:
    * dancex11/scheduler/events/passivate.h:
    * dancex11/scheduler/events/remove.h:
    * dancex11/scheduler/events/start.h:
    * tools/artifact_installation/artifact_installation_handler_svc.h:
    * tools/artifact_installation/artifact_installation_impl.h:
    * tools/artifact_installation/dance_artifact_installation_handler.h:
    * tools/artifact_installation/file_installation_handler.h:
    * tools/artifact_installation/http_installation_handler.cpp:
    * tools/artifact_installation/http_installation_handler.h:
    * tools/artifact_installation/installation_repository_manager.h:
    * tools/artifact_installation/installation_repository_manager_impl.h:
    * tools/config_handlers/dancex11_deployment_cdp_plan_loader.h:
    * tools/split_plan/sub_uuid_generator.cpp:
    * tools/split_plan/sub_uuid_generator.h: