### PR TITLE
Update linux.yml

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,7 +58,7 @@ jobs:
             CXX: g++-10
             ruby: '2.7'
             PackageDeps: g++-10
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc-11
             CXX: g++-11
             ruby: '3.0'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,12 +73,11 @@ jobs:
             CXX: g++-12
             ruby: '3.2'
             PackageDeps: g++-12
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             CC: gcc-13
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
-            Repo: ppa:ubuntu-toolchain-r/test            
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }}
     env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,6 +78,7 @@ jobs:
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
+            Repo: ppa:ubuntu-toolchain-r/test            
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }}
     env:


### PR DESCRIPTION
gcc-13 has been removed from ubuntu-22.04, see https://github.com/actions/runner-images/issues/9866